### PR TITLE
Send traffic-splitter metrics to statful

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,0 +1,19 @@
+'use strict'
+
+const STATUS = Object.freeze({
+  SUCCESS: 'success',
+  ERROR: 'error'
+})
+
+const SOCKETS_PROPERTIES = Object.freeze([
+  'createSocketCount',
+  'createSocketErrorCount',
+  'closeSocketCount',
+  'errorSocketCount',
+  'timeoutSocketCount'
+])
+
+module.exports = {
+  STATUS,
+  SOCKETS_PROPERTIES
+}

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,5 +1,94 @@
 'use strict'
 
-module.exports = function StatfulTrafficSplitter (statful, splitter) {
+const { filterUndefinedProperties } = require('./utils')
+const { SOCKETS_PROPERTIES, STATUS: { SUCCESS, ERROR } } = require('./constants')
 
+module.exports = function StatfulTrafficSplitter (statful, splitter) {
+  const { events } = splitter
+
+  events.on('applicationStart', () => {
+    statful.counter('application_start', 1)
+  })
+
+  events.on('serverStart', () => {
+    statful.counter('server_start', 1)
+  })
+
+  events.on('rulesProcessing', (duration, selectedUpstream) => {
+    statful.timer('rules_processing', duration, { tags: { selectedUpstream } })
+  })
+
+  events.on('noUpstreamFound', (req) => {
+    statful.counter('no_upstream_found', 1)
+  })
+
+  events.on('resFinish', (req, res, duration) => {
+    const { method, upstream } = req
+    const { statusCode } = res
+    const { name } = getUpstreamTags(upstream)
+
+    const tags = { method, statusCode, name }
+
+    statful.timer('response', duration, { tags })
+  })
+
+  const sendUpstreamMetric = (upstream, duration, customTags) => {
+    const upstreamTags = getUpstreamTags(upstream)
+    const tags = Object.assign({}, upstreamTags, customTags)
+
+    statful.timer('upstream', duration, { tags })
+  }
+
+  // this event handles both serve and serveSecure upstream types
+  events.on('serving', (statusCode, upstream, duration, host, upstreamReq, upstreamRes) => {
+    const contentLength = upstreamRes.contentLength()
+
+    sendUpstreamMetric(upstream, duration, { statusCode, contentLength, status: SUCCESS })
+  })
+
+  events.on('servingError', (e, upstream, duration, upstreamReq) => {
+    sendUpstreamMetric(upstream, duration, { status: ERROR })
+  })
+
+  events.on('servingFile', (upstream, duration) => {
+    sendUpstreamMetric(upstream, duration, { status: SUCCESS })
+  })
+
+  events.on('servingFileError', (e, upstream, duration) => {
+    sendUpstreamMetric(upstream, duration, { status: ERROR })
+  })
+
+  events.on('redirecting', (statusCode, upstream, duration) => {
+    sendUpstreamMetric(upstream, duration, { status: SUCCESS, statusCode })
+  })
+
+  events.on('upstreamException', (e, upstream) => {
+    const { name, type } = getUpstreamTags(upstream)
+
+    statful.counter('upstream_exception', 1, { tags: { name, type } })
+  })
+
+  const emitAgentStatusMetrics = (agentStatus, type) => {
+    statful.gauge('request', agentStatus.requestCount)
+
+    SOCKETS_PROPERTIES.forEach(property => {
+      const tags = { type, property }
+
+      statful.gauge('sockets', agentStatus[property], { tags })
+    })
+  }
+
+  events.on('httpSocketMetrics', (agentStatus) => {
+    emitAgentStatusMetrics(agentStatus, 'http')
+  })
+
+  events.on('httpsSocketMetrics', (agentStatus) => {
+    emitAgentStatusMetrics(agentStatus, 'https')
+  })
+}
+
+function getUpstreamTags (upstream) {
+  const { name, upstream: { type, options: { host, file } } } = upstream
+
+  return filterUndefinedProperties({ name, type, host, file })
 }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,0 +1,15 @@
+'use strict'
+
+module.exports = {
+  filterUndefinedProperties
+}
+
+function filterUndefinedProperties (object) {
+  return Object.keys(object).reduce((result, key) => {
+    if (typeof object[key] !== 'undefined') {
+      result[key] = object[key]
+    }
+
+    return result
+  }, {})
+}


### PR DESCRIPTION
This PR contains the logic to send traffic-splitter metrics to statful.

Basically we are just listening to traffic-splitter events and using its arguments to send metrics to statful using statful-client. Ping me if you would like a project integrating this plugin for testing.

Please do review this to see if the metrics make sense :)